### PR TITLE
Add Trait Support for Models in Lucent ORM

### DIFF
--- a/tests/Unit/ModelTest.php
+++ b/tests/Unit/ModelTest.php
@@ -2,12 +2,16 @@
 
 namespace Unit;
 
+use App\Extensions\View\View;
 use App\Models\Admin;
 use App\Models\TestUser;
+use App\Models\TestUserTwo;
 use Lucent\Database;
+use Lucent\Database\Attributes\DatabaseColumn;
 use Lucent\Database\Dataset;
 use Lucent\Facades\CommandLine;
 use Lucent\Filesystem\File;
+use Lucent\ModelCollection;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 // Manually require the DatabaseDriverSetup file
@@ -359,6 +363,71 @@ class ModelTest extends DatabaseDriverSetup
         $this->assertEquals("Successfully performed database migration",$output);
     }
 
+    #[DataProvider('databaseDriverProvider')]
+    public function test_model_migration_with_trait($driver,$config) : void
+    {
+        self::setupDatabase($driver, $config);
+
+        $this->assertTrue($this->generate_soft_delete_trait()->exists());
+        $this->assertTrue($this->generate_soft_delete_trait_model()->exists());
+
+        $output = CommandLine::execute("Migration make App/Models/TestUserTwo");
+        $this->assertEquals("Successfully performed database migration",$output);
+    }
+
+    #[DataProvider('databaseDriverProvider')]
+    public function test_model_trait_use($driver,$config) : void
+    {
+        self::setupDatabase($driver, $config);
+        $this->test_model_migration_with_trait($driver,$config);
+
+        $user = new \App\Models\TestUserTwo(new Dataset([
+            "full_name" => "John Smith",
+            "email" => "john.smith@test.com",
+            "password_hash" => "password",
+        ]));
+
+        $this->assertTrue($user->create());
+
+        $this->assertTrue($user->delete());
+
+        $user = \App\Models\TestUserTwo::where("email","john.smith@test.com")->getFirst();
+        $this->assertNotNull($user->deleted_at);
+    }
+
+    #[DataProvider('databaseDriverProvider')]
+    public function test_model_trait_model_collection_hook($driver, $config): void
+    {
+        self::setupDatabase($driver, $config);
+        $this->test_model_migration_with_trait($driver,$config);
+
+        // Create and save a model
+        $user = new \App\Models\TestUserTwo(new Dataset([
+            'email' => 'john.smith@test.com',
+            'password_hash' => 'password',
+            'full_name' => 'John Smith'
+        ]));
+        $this->assertTrue($user->create());
+
+        // Soft delete the model
+        $this->assertTrue($user->delete());
+
+        // Register the trait condition
+        ModelCollection::registerTraitCondition(
+            \App\Models\SoftDelete::class,
+            'deleted_at',
+            null
+        );
+
+        // This should return zero records as they're all soft-deleted
+        $users = \App\Models\TestUserTwo::where("email", "john.smith@test.com")->get();
+        $this->assertCount(0, $users);
+
+        // Test the withTrashed method if implemented
+        // $users = TestUserTwo::where("email", "john.smith@test.com")->withTrashed()->get();
+        // $this->assertCount(1, $users);
+    }
+
 
     public static function generate_test_model(): File
     {
@@ -562,5 +631,142 @@ PHP;
         return new File("/App/Models/LongTextModel.php",$modelContent);
 
     }
+
+    public static function generate_soft_delete_trait(): File
+    {
+        $modelContent = <<<'PHP'
+        <?php
+        
+        namespace App\Models;
+        
+        use Lucent\Database\Attributes\DatabaseColumn;
+        use Lucent\Database\Dataset;
+        use Lucent\Model;
+        
+        trait SoftDelete
+        {
+            #[DatabaseColumn([
+                "TYPE"=>LUCENT_DB_INT,
+                "ALLOW_NULL"=>true
+            ])]
+            public private(set) ?int $deleted_at = null;
+        
+            /**
+             * Override the base delete method with a soft delete implementation
+             *
+             * @param mixed $propertyName The primary key property name
+             * @return bool Success
+             */
+            public function delete($propertyName = "id"): bool
+            {
+                return $this->softDelete($propertyName);
+            }
+        
+            /**
+             * Delete the model by setting the deleted_at timestamp
+             *
+             * @param string $propertyName The primary key property name
+             * @return bool Success
+             */
+            public function softDelete(string $propertyName = "id"): bool
+            {
+                $this->deleted_at = time();
+                return $this->save($propertyName);
+            }
+        
+            /**
+             * Restore a soft deleted model
+             *
+             * @return bool Success
+             */
+            public function restore(): bool
+            {
+                $this->deleted_at = null;
+                return $this->save();
+            }
+        
+        }
+        PHP;
+
+
+        return new File("/App/Models/SoftDelete.php",$modelContent);
+
+    }
+
+    public static function generate_soft_delete_trait_model(): File
+    {
+        $modelContent = <<<'PHP'
+        <?php
+        
+        namespace App\Models;
+        
+        use Lucent\Database\Attributes\DatabaseColumn;
+        use Lucent\Database\Dataset;
+        use Lucent\Model;
+        use App\Models\SoftDelete;
+        
+        class TestUserTwo extends Model
+        {
+         use SoftDelete;
+        
+            #[DatabaseColumn([
+                "PRIMARY_KEY"=>true,
+                "TYPE"=>LUCENT_DB_INT,
+                "ALLOW_NULL"=>false,
+                "AUTO_INCREMENT"=>true,
+                "LENGTH"=>255
+            ])]
+            public private(set) ?int $id;
+        
+            #[DatabaseColumn([
+                "TYPE"=>LUCENT_DB_VARCHAR,
+                "ALLOW_NULL"=>false
+            ])]
+            protected string $email;
+        
+            #[DatabaseColumn([
+                "TYPE"=>LUCENT_DB_VARCHAR,
+                "ALLOW_NULL"=>false
+            ])]
+            protected string $password_hash;
+        
+            #[DatabaseColumn([
+                "TYPE"=>LUCENT_DB_VARCHAR,
+                "ALLOW_NULL"=>false,
+                "LENGTH"=>100
+            ])]
+            protected string $full_name;
+        
+            public function __construct(Dataset $dataset){
+                $this->id = $dataset->get("id",-1);
+                $this->email = $dataset->get("email");
+                $this->password_hash = $dataset->get("password_hash");
+                $this->full_name = $dataset->get("full_name");
+                $this->deleted_at = $dataset->get("deleted_at");
+            }
+        
+            public function getFullName() : string{
+                return $this->full_name;
+            }
+            
+            public function setFullName(string $full_name){
+                $this->full_name = $full_name;
+            }
+            
+            public function getId() : int
+            {
+                return $this->id;
+            }
+        
+        
+        }
+        PHP;
+
+
+        return new File("/App/Models/TestUserTwo.php",$modelContent);
+
+    }
+
+
 
 }


### PR DESCRIPTION
This PR introduces support for PHP traits in Lucent models with the ability to automatically apply query conditions based on model traits.

**Changes:**

- Added support for DatabaseColumn attributes in model traits
- Implemented ModelCollection::registerTraitCondition for automatic trait-based query scopes
- Updated ModelCollection::buildQuery to handle trait conditions
- Added recursive trait detection for proper inheritance handling